### PR TITLE
Fix outdated link to mybinder.org on index page of documentation

### DIFF
--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -30,7 +30,7 @@ the `Project Jupyter <https://docs.jupyter.org/en/latest/>`_ umbrella, like
 offers a more advanced, feature rich, customizable experience compared to
 Jupyter Notebook.
 
-`Try JupyterLab on Binder <https://mybinder.org/v2/gh/jupyterlab/jupyterlab-demo/3818244?urlpath=lab/tree/demo>`__.  JupyterLab follows the Jupyter `Community Guides <https://jupyter.readthedocs.io/en/latest/community/content-community.html>`__.
+`Try JupyterLab on Binder <https://mybinder.org/v2/gh/jupyterlab/jupyterlab-demo/HEAD?urlpath=lab/tree/demo>`__.  JupyterLab follows the Jupyter `Community Guides <https://jupyter.readthedocs.io/en/latest/community/content-community.html>`__.
 
 .. image:: ./images/jupyterlab.png
    :align: center


### PR DESCRIPTION
This PR is in response to #15799

The current link "Try JupyterLab on Binder" on `index.rst` points to the commit 

https://github.com/jupyterlab/jupyterlab-demo/commit/3818244680a477cdead8182216f5c87e685e0bee

which is not producing a valid binder image anymore.

Here, the link is changed to point to HEAD, like in `README.md`, which yields a functioning binder session.